### PR TITLE
将绩点字段改为学分，增加“学分”信息

### DIFF
--- a/course.py
+++ b/course.py
@@ -55,7 +55,7 @@ class Course:
                         "elements": [{
                                 "tag": "div",
                                 "text": {
-                        "content": f"总分：**{self.total_score}** \n学分：**{self.gpa}**\n课程ID: {self.course_id}",
+                      "content": f"总分：**{self.total_score}**\n学分：**{self.credit}** \n绩点：**{self.gpa}**\n课程ID: {self.course_id}",
                                         "tag": "lark_md"
                                 }
                         }],


### PR DESCRIPTION
#### 变更内容
- 将原代码中的“绩点”字段修改为“学分”，增加学分字段

#### 具体修改
在代码中，将以下行：
```python
"content": f"总分：**{self.total_score}**\n绩点：**{self.gpa}**\n课程ID: {self.course_id}",
```
修改为：
```python
"content": f"总分：**{self.total_score}**\n学分：**{self.credit}** \n绩点：**{self.gpa}**\n课程ID: {self.course_id}",
```

#### 目的
修复原先的错误，增加学分字段让信息更加详细